### PR TITLE
Fix SourceMod 1.8 compilation

### DIFF
--- a/addons/sourcemod/scripting/Api.sp
+++ b/addons/sourcemod/scripting/Api.sp
@@ -212,7 +212,11 @@ public Native_RemoveGame(Handle:hPlugin, iNumParams)
 public Native_ShowPlayerSelectMenu(Handle:hPlugin, iNumParams)
 {
 	new iClient = GetNativeCell(1);
+#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
+	new Function:fCallBack = GetNativeFunction(2);
+#else
 	new Function:fCallBack = Function:GetNativeCell(2);
+#endif
 	new bool:bRedTeam = bool:GetNativeCell(3);
 	new bool:bBlueTeam = bool:GetNativeCell(4);
 	new bool:bRandom = bool:GetNativeCell(5);

--- a/addons/sourcemod/scripting/PlayerData.sp
+++ b/addons/sourcemod/scripting/PlayerData.sp
@@ -176,7 +176,7 @@ SavePlayerEquipment(iClient, bool:bSaveHP = true, bool:bSaveArmor = true)
 		if (g_iEngineVersion == Engine_CSGO) {
 			iPrimaryAmmo = GetEntProp(iTaser, Prop_Send, "m_iPrimaryReserveAmmoCount");
 		} else {
-			iPrimaryAmmo = GetEntData(iClient, FindDataMapOffs(iClient, "m_iAmmo") + (Weapon_GetPrimaryAmmoType(iTaser) * 4));
+			iPrimaryAmmo = GetEntData(iClient, FindDataMapInfo(iClient, "m_iAmmo") + (Weapon_GetPrimaryAmmoType(iTaser) * 4));
 		}
 	}
 
@@ -190,7 +190,7 @@ SavePlayerEquipment(iClient, bool:bSaveHP = true, bool:bSaveArmor = true)
 		if (g_iEngineVersion == Engine_CSGO) {
 			iPrimaryAmmo = GetEntProp(iWeaponEntity, Prop_Send, "m_iPrimaryReserveAmmoCount");
 		} else {
-			iPrimaryAmmo = GetEntData(iClient, FindDataMapOffs(iClient, "m_iAmmo") + (Weapon_GetPrimaryAmmoType(iWeaponEntity) * 4));
+			iPrimaryAmmo = GetEntData(iClient, FindDataMapInfo(iClient, "m_iAmmo") + (Weapon_GetPrimaryAmmoType(iWeaponEntity) * 4));
 		}
 	}
 
@@ -204,7 +204,7 @@ SavePlayerEquipment(iClient, bool:bSaveHP = true, bool:bSaveArmor = true)
 		if (g_iEngineVersion == Engine_CSGO) {
 			iSecondaryAmmo = GetEntProp(iWeaponEntity, Prop_Send, "m_iPrimaryReserveAmmoCount");
 		} else {
-			iSecondaryAmmo = GetEntData(iClient, FindDataMapOffs(iClient, "m_iAmmo") + (Weapon_GetPrimaryAmmoType(iWeaponEntity) * 4));
+			iSecondaryAmmo = GetEntData(iClient, FindDataMapInfo(iClient, "m_iAmmo") + (Weapon_GetPrimaryAmmoType(iWeaponEntity) * 4));
 		}
 	}
 

--- a/addons/sourcemod/scripting/TeamGames.sp
+++ b/addons/sourcemod/scripting/TeamGames.sp
@@ -97,7 +97,7 @@ public OnPluginStart()
 	LoadTranslations("common.phrases");
 	LoadTranslations("TeamGames.phrases");
 
-	CreateConVar("tg_version", _PLUGIN_VERSION, "TeamGames core version (not changeable)", FCVAR_PLUGIN|FCVAR_NOTIFY|FCVAR_SPONLY|FCVAR_REPLICATED|FCVAR_DONTRECORD);
+	CreateConVar("tg_version", _PLUGIN_VERSION, "TeamGames core version (not changeable)", FCVAR_NOTIFY|FCVAR_SPONLY|FCVAR_REPLICATED|FCVAR_DONTRECORD);
 
 	g_hAutoUpdate = 				CreateConVar("tg_autoupdate", 				"1", 						"Should TeamGames use plugin Updater? (https://forums.alliedmods.net/showthread.php?t=169095) (1 = true, 0 = false)");
 	g_hLogTime = 					CreateConVar("tg_logtime", 					"72.0", 					"How long should logs be hold (in hours)\n\t0.0 = logging turned off\n\t-1.0 = loggin on + logs are held forever\n\t>0.0 = loggin on + older logs are deleted", _, true, -1.0, true, 600.0);

--- a/addons/sourcemod/scripting/include/teamgames-stocks.inc
+++ b/addons/sourcemod/scripting/include/teamgames-stocks.inc
@@ -266,7 +266,11 @@ stock RequestFrame2(RequestFrameCallback:func, framesAhead = 1, any:data = 0)
 		RequestFrame(func, data);
 	} else {
 		new Handle:pack = CreateDataPack();
+#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
+		WritePackFunction(pack, func);
+#else
 		WritePackCell(pack, func);
+#endif
 		WritePackCell(pack, framesAhead);
 		WritePackCell(pack, data);
 
@@ -277,7 +281,11 @@ stock RequestFrame2(RequestFrameCallback:func, framesAhead = 1, any:data = 0)
 public RequestFrame2_CallBack(any:pack)
 {
 	ResetPack(Handle:pack);
+#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
+	new RequestFrameCallback:func = RequestFrameCallback:ReadPackFunction(Handle:pack);
+#else
 	new RequestFrameCallback:func = RequestFrameCallback:ReadPackCell(Handle:pack);
+#endif
 	new framesAhead = ReadPackCell(Handle:pack) - 1;
 	new data = ReadPackCell(Handle:pack);
 	CloseHandle(Handle:pack);
@@ -297,7 +305,7 @@ stock GivePlayerWeaponAndAmmo(client, String:weapon[], clip = -1, ammo = -1)
 			SetEntProp(weaponEnt, Prop_Send, "m_iClip1", clip);
 
 		if (ammo != -1) {
-			new iOffset = FindDataMapOffs(client, "m_iAmmo") + (GetEntProp(weaponEnt, Prop_Data, "m_iPrimaryAmmoType") * 4);
+			new iOffset = FindDataMapInfo(client, "m_iAmmo") + (GetEntProp(weaponEnt, Prop_Data, "m_iPrimaryAmmoType") * 4);
 			SetEntData(client, iOffset, ammo, 4, true);
 
 			if (GetEngineVersion() == Engine_CSGO) {

--- a/addons/sourcemod/scripting/modules/TG_HEGrenades.sp
+++ b/addons/sourcemod/scripting/modules/TG_HEGrenades.sp
@@ -89,7 +89,7 @@ GiveGrenade(client)
 
 	SetEntProp(grenade, Prop_Send, "m_iClip1", 1);
 
-	new offset = FindDataMapOffs(client, "m_iAmmo") + (GetEntProp(grenade, Prop_Data, "m_iPrimaryAmmoType") * 4);
+	new offset = FindDataMapInfo(client, "m_iAmmo") + (GetEntProp(grenade, Prop_Data, "m_iPrimaryAmmoType") * 4);
 	SetEntData(client, offset, 1, 4, true);
 
 	if (GetEngineVersion() == Engine_CSGO) {


### PR DESCRIPTION
Fix all warnings and errors when compiling using the SM 1.8 compiler and
includes.

Will still show some warnings in the menu-stocks include, but those
can't be fixed, because functions can't safely be converted to strings
and back.

Also hi :smile: nice documentation you've got there!